### PR TITLE
Add link to english docs in navbar

### DIFF
--- a/_navbar.md
+++ b/_navbar.md
@@ -1,0 +1,1 @@
+* [English](https://neow3j.io)

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
       name: ' ',
       repo: 'https://github.com/neow3j/neow3j',
       loadSidebar: true,
+      loadNavbar: true,
       homepage: '/README.md',
       alias: {
         '/_sidebar.md': '/_sidebar.md'


### PR DESCRIPTION
Adding a link to the top right that directs to the english docs.
I'm doing the same on the english page:
![Screenshot 2023-01-18 at 17 46 29](https://user-images.githubusercontent.com/37138571/213242630-e996a0cf-f068-42b5-a980-72c852f900e9.png)
